### PR TITLE
Add recent meetings

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@ layout: default
   {% if page.recording_url %}
   <p><a href="{{ page.recording_url }}" class="button radius"><i class="fi-play-video"></i> Watch the recorded session</a></p>
   {% else %}
-  <p><a href="https://umn.webex.com/umn/j.php?MTID=m3d59c154fc41c4c37c9cd2d52491368c" class="button radius success"><i class="fi-play-video"></i> Participate online</a></p>
+  <p><a href="http://z.umn.edu/cpmwebex" class="button radius success"><i class="fi-play-video"></i> Participate online</a></p>
   {% endif %}
 
   {{ content }}

--- a/_posts/2015-06-04-f5-testing-meet-the-housing-dev-group.markdown
+++ b/_posts/2015-06-04-f5-testing-meet-the-housing-dev-group.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: F5 load balancer overview, Testing with Ian, and meet the housing dev team
 date:   2015-06-04 09:30
-categories: upcoming
+categories: meetings
 recording_url:
 ---
 
@@ -25,4 +25,3 @@ plan around.
 - 10:50-11:00: Lightning Talk (Or update on consensus workshop)
 
 As always, Lunch to follow (On the plaza by McNamara - let's try this again.)
-

--- a/_posts/2015-06-30-mysql-hosting-testing-legacy-code.markdown
+++ b/_posts/2015-06-30-mysql-hosting-testing-legacy-code.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: Hosted Mysql, Testing legacy code, and meet the Peoplesoft dev team
 date:   2015-06-30 09:30
-categories: upcoming
+categories: meetings
 recording_url:
 ---
 

--- a/_posts/2015-06-30-mysql-hosting-testing-legacy-code.markdown
+++ b/_posts/2015-06-30-mysql-hosting-testing-legacy-code.markdown
@@ -3,7 +3,7 @@ layout: post
 title: Hosted Mysql, Testing legacy code, and meet the Peoplesoft dev team
 date:   2015-06-30 09:30
 categories: meetings
-recording_url:
+recording_url: https://umn.webex.com/umn/ldr.php?RCID=6aefb894bc243cc8873c9f4c1a9156dc
 ---
 
 Location\: [Walter Library](http://campusmaps.umn.edu/tc/map.php?building=042), Room 402

--- a/_posts/2015-08-06-testing-infrastructure-and-php-database-apis.markdown
+++ b/_posts/2015-08-06-testing-infrastructure-and-php-database-apis.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Testing infrastructure and PHP database APIs
-date:   2015-06-30 09:30
+date:   2015-08-06 09:30
 categories: meetings
 recording_url:
 ---

--- a/_posts/2015-08-06-testing-infrastructure-and-php-database-apis.markdown
+++ b/_posts/2015-08-06-testing-infrastructure-and-php-database-apis.markdown
@@ -1,0 +1,44 @@
+---
+layout: post
+title: Testing infrastructure and PHP database APIs
+date:   2015-06-30 09:30
+categories: meetings
+recording_url:
+---
+
+Location\: [Walter Library](http://campusmaps.umn.edu/tc/map.php?building=042), Room 402
+
+Good Day Code Peoples and DevOpsers!
+
+In an effort to be more proactive, we are sending out our agenda
+far ahead of our planned meeting, so that you all can plan
+around it. We are committing to keeping to this (of course,
+expect the unexpected) so that it will be easier for you to
+plan around.
+
+### Tentative agenda
+
+- 9:30-10:00: Testing Infrastructure
+- 10:00-10:15: CCF Q&A
+- 10:15-10:45: PHP Database APIs Today
+- 10:45-11:00: Lightning Talks
+
+Lunch will be at Burrito Loco!
+
+For those of you that are interested - we will be hosting a
+training session with Sandi Metz (Practical Object-Oriented
+Design in Ruby) the last week in January. If you are
+interested, please let us know ASAP. Kemal Badur (kemal@umn.edu)
+will be handling the logistics on this.
+
+Have a great day, and we hope to see you next month! Stay tuned for
+some exciting news on "brown bag" lunches to discuss some of
+the topics that came out of our consensus workshop, as well as
+some potential "deep dives".
+
+Planned upcoming "brown bag" sessions:
+
+- Apache configuration
+- DevOps cookbook delves
+- Accessibility and UI
+- others?

--- a/_posts/2015-09-03-lunch.markdown
+++ b/_posts/2015-09-03-lunch.markdown
@@ -1,0 +1,15 @@
+---
+layout: post
+title: Lunch
+date:   2015-09-03
+categories: meetings
+recording_url:
+---
+
+Afternoon, Code People!
+
+Sad news, we are cancelling our September meeting because our presenters got pulled into last-minute....things. Things!
+
+However, lunch still seems like a nice plan. Everyone likes lunch! We'll meet at Stub & Herb's at 11:30 to grab food and beverages. Join us!
+
+When we have the October itinerary, we'll send it out to y'all.

--- a/_posts/2015-10-01-tmux-and-accessibility.markdown
+++ b/_posts/2015-10-01-tmux-and-accessibility.markdown
@@ -1,0 +1,34 @@
+---
+layout: post
+title: Tmux and accessibility
+date:   2015-10-01 09:30
+categories: meetings
+recording_url:
+---
+
+Location\: [Walter Library](http://campusmaps.umn.edu/tc/map.php?building=042), Room 402
+
+Sugeng énjing, Code People!
+
+Please join us on Thursday, October 1, for another action-packed episode of Code-People!
+
+### Lightning talks
+
+We're trying to be more intentional about pestering you all to come up and share with the group. Want to show-n-tell a cool project you're working on? Found a new cool way to deal with an old issue? Are you experimenting with a new language or framework? Spend a few minutes talking about it! It's super informal (you can wing it if you want!) and it *has* to be less than five minutes, so the commitment is small.
+
+### Donuts!!!
+
+Also, Ian will be bringing a pile of donuts from Sssdude-Nutz in Dinkytown—come early and enjoy one!
+
+### Agenda
+
+- 9:30-9:35 - Welcome and announcements (Chris Dinger)
+- 9:35-9:45 - Upcoming Oracle DB changes (Andy Wattenhofer)
+- 9:45-10:00 - tmux overview (Michael Berkowski)
+- 10:00-10:30 - Accessibility info for coders (Kim Doberstein)
+- 10:30-10:45 - RedHat 7 progress report (Ben Larson)
+- 10:45-11:00 - Lightning talks (this is YOU!)
+
+This month we'll be heading over to Surly Brewing for lunch after the meeting.
+
+I hope to see you all there!

--- a/_posts/2015-11-05-meet-the-peoplesoft-team-and-refactoring.markdown
+++ b/_posts/2015-11-05-meet-the-peoplesoft-team-and-refactoring.markdown
@@ -1,0 +1,26 @@
+---
+layout: post
+title: Meet the Peoplesoft team and Refactoring
+date:   2015-11-05 09:30
+categories: upcoming
+recording_url:
+---
+
+Location\: [Walter Library](http://campusmaps.umn.edu/tc/map.php?building=042), Room 402
+
+Good afternoon everyone,
+
+In an effort to be more proactive, we are sending out our agenda far ahead of our planned meeting, so that you all can plan around it. We are committing to keeping to this (of course, expect the unexpected) so that it will be easier for you to plan around.
+
+### Tentative agenda
+
+- 9:30-10:00:	Meet a Development Group: PeopleSoft (Jeremy Irrthum)
+- 10:00-10:15:	GitHub Announcements (Jake Gage)
+- 10:15-10:35:	Practicing Refactoring (Ian Whitney)
+- 10:35-11:00:	Lightning talks
+  - Progress on institutional CI (Jake)
+  - Overcommit (Debbie)
+  - A talk on Lightning Talks
+  - Bring your ideas!
+
+We are planning for lunch at Burrito Loco, and we'll post it on the whiteboard during the meeting.


### PR DESCRIPTION
This adds the recent meetings I've neglected and adds past recording URLs to code-people.umn.edu.

Does anybody know if there's a way to lookup old recording URLs for past meetings? I'm still missing a few.

Also, according to analytics, [not a lot of people use this site](https://analytics.google.com/analytics/web/#report/visitors-overview/a53760917w90970605p94621934/).  I think this means we should either build this into the announcement process or get rid of it. I think it's nice to be able to refer back to old meetings and view the videos, but I'll admit I haven't found myself doing this much. At the least we should talk about it at the next committee meeting.