### PR TITLE
Track Gemfile.lock in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 _site
 /vendor/bundle
-Gemfile.lock
 /.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorator (0.1)
+    ffi (1.9.10)
+    jekyll (3.1.1)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.3.1)
+      listen (~> 3.0)
+    kramdown (1.9.0)
+    liquid (3.0.6)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.21)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  kramdown
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
I'm not sure why this file was in .gitinore. Without it, any person who
works on the site will get a different set of gems. I think we should
have this in git.