### PR TITLE
Presenter Guidelines

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,7 +57,7 @@
           <ul class="inline-list right">
             <li class="active"><a href="/">Home</a></li>
             <li><a href="/meetings/">Meetings</a></li>
-            <li><a href="/speaker_info/">Speaker Guidelines</a></li>
+            <li><a href="/speaker_info/">Presenter Guidelines</a></li>
             <li><a href="/about/">About</a></li>
           </ul>
         </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,6 +57,7 @@
           <ul class="inline-list right">
             <li class="active"><a href="/">Home</a></li>
             <li><a href="/meetings/">Meetings</a></li>
+            <li><a href="/speaker_info/">Speaker Guidelines</a></li>
             <li><a href="/about/">About</a></li>
           </ul>
         </nav>
@@ -102,4 +103,3 @@
   </script>
 </body>
 </html>
-

--- a/speaker_info/index.html
+++ b/speaker_info/index.html
@@ -6,6 +6,27 @@ title: About Code-People
 <div class="large-12 columns">
   <h2>Speaker Guidelines</h2>
 
-  
+  <p>Scheduled to give a talk at an upcoming Code People meeting? Great! We’re psyched to hear what you have to share.</p>
 
+  <p>We strongly prefer presentations that are available via a public URL, like Google Slides. If you must present using your own laptop, here is a list of things to check to make sure your talk goes as smooth as possible!</p>
+
+  <ol>
+    <li>Install WebEx
+      <ul>
+          <li>You can get the browser plugin here</li>
+          <li>Or you can join the Code People webex, which will be listed on the meeting on our site. Your browser should prompt you to install the plugin.</li>
+      </ul>
+    </li>
+    <li>Turn off your desktop notifications</li>
+    <li>Make sure your laptop can connect to our displays
+      The following connections are available for you to use. If your laptop uses USB-C or some other connection, make sure you bring the appropriate adapter.
+      <ul>
+          <li>VGA</li>
+          <li>HDMI</li>
+          <li>Thunderbolt</li>
+      </ul>
+    </li>
+    <li>Make sure your laptop is charged</li>
+    <li>If possible, connect to the network via ethernet</li>
+  </ol>
 </div>

--- a/speaker_info/index.html
+++ b/speaker_info/index.html
@@ -1,0 +1,11 @@
+---
+layout: default
+title: About Code-People
+---
+
+<div class="large-12 columns">
+  <h2>Speaker Guidelines</h2>
+
+  
+
+</div>

--- a/speaker_info/index.html
+++ b/speaker_info/index.html
@@ -6,7 +6,7 @@ title: About Code-People
 <div class="large-12 columns">
   <h2>Speaker Guidelines</h2>
 
-  <p>Scheduled to give a talk at an upcoming Code People meeting? Great! We’re psyched to hear what you have to share.</p>
+  <p>Scheduled to give a talk at an upcoming Code People meeting? Great! We're excited to learn from you.</p>
 
   <p>We strongly prefer presentations that are available via a public URL, like <a href="https://www.google.com/slides/about">Google Slides</a>.<br>If you must present using your own laptop, here is a list of things to check to make sure your talk goes as smooth as possible!</p>
 

--- a/speaker_info/index.html
+++ b/speaker_info/index.html
@@ -8,12 +8,12 @@ title: About Code-People
 
   <p>Scheduled to give a talk at an upcoming Code People meeting? Great! We’re psyched to hear what you have to share.</p>
 
-  <p>We strongly prefer presentations that are available via a public URL, like Google Slides. If you must present using your own laptop, here is a list of things to check to make sure your talk goes as smooth as possible!</p>
+  <p>We strongly prefer presentations that are available via a public URL, like <a href="https://www.google.com/slides/about">Google Slides</a>.<br>If you must present using your own laptop, here is a list of things to check to make sure your talk goes as smooth as possible!</p>
 
   <ol>
     <li>Install WebEx
       <ul>
-          <li>You can get the browser plugin here</li>
+          <li>You can get the browser plugin <a href="https://umn.webex.com">here</a></li>
           <li>Or you can join the Code People webex, which will be listed on the meeting on our site. Your browser should prompt you to install the plugin.</li>
       </ul>
     </li>

--- a/speaker_info/index.html
+++ b/speaker_info/index.html
@@ -18,7 +18,7 @@ title: About Code-People
       </ul>
     </li>
     <li>Turn off your desktop notifications</li>
-    <li>Make sure your laptop can connect to our displays
+    <li>Make sure your laptop can connect to our displays.<br>
       The following connections are available for you to use. If your laptop uses USB-C or some other connection, make sure you bring the appropriate adapter.
       <ul>
           <li>VGA</li>
@@ -26,7 +26,7 @@ title: About Code-People
           <li>Thunderbolt</li>
       </ul>
     </li>
-    <li>Make sure your laptop is charged</li>
-    <li>If possible, connect to the network via ethernet</li>
+    <li>Make sure your laptop is charged.</li>
+    <li>If possible, connect to the network via ethernet.</li>
   </ol>
 </div>

--- a/speaker_info/index.html
+++ b/speaker_info/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: About Code-People
+title: Speaker Guidelines
 ---
 
 <div class="large-12 columns">

--- a/speaker_info/index.html
+++ b/speaker_info/index.html
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Speaker Guidelines
+title: Presenter Guidelines
 ---
 
 <div class="large-12 columns">
-  <h2>Speaker Guidelines</h2>
+  <h2>Presenter Guidelines</h2>
 
   <p>Scheduled to give a talk at an upcoming Code People meeting? Great! We're excited to learn from you.</p>
 


### PR DESCRIPTION
Added a page to list guidelines for presenters to help them better prepare to give talks at Code People. 