### PR TITLE
Request a talk page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,19 @@ title: Code-People at the University of Minnesota
   <h4 class="subheader">We are an open network of <a href="http://www.umn.edu/">University of Minnesota</a> application developers looking to further our programming skills & capacity to innovate by meeting monthly to share tools & tricks of the trade via presentations, workshops, and facilitated discussions.</h4>
 </div>
 <div class="row">
-  <p class="join large-6 column">
+  <p class="join large-4 column">
     <a href="https://groups.google.com/a/umn.edu/forum/#!forum/code-people" class="large button success radius">
       Join the Google Group
     </a>
   </p>
-  <p class="join large-6 column">
+  <p class="join large-4 column">
     <a href="slack.html" class="large button success radius">
       Join the Slack
+    </a>
+  </p>
+  <p class="join large-4 column">
+    <a href="request.html" class="large button success radius">
+      Request a Talk
     </a>
   </p>
 </div>
@@ -50,4 +55,3 @@ title: Code-People at the University of Minnesota
   </ul>
   <p><a href="/meetings">See all meetings</a>
 </div>
-

--- a/request.md
+++ b/request.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Request a Talk
+---
+
+Have an idea for a talk? We'd love to hear it!
+We use GitHub Issues to track talk ideas.
+
+- Go to [https://github.umn.edu/code-people/meetings/issues](https://github.umn.edu/code-people/meetings/issues)
+- Click _New Issue_
+- Enter a title and description for your idea
+- Choose a label for the issue depending on if it's a Talk Idea or a Lightning Talk Idea
+- Click _Submit new issue_ when you're ready to submit your idea
+
+Once your idea is submitted, we'll get back to you about it!


### PR DESCRIPTION
Added a page describing how to submit talk ideas.
This page is linked to from the landing page with a green button.
Solution for  #19 