### PR TITLE
Changed about page to point to Request a Talk page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,7 +34,7 @@ title: About Code-People
     <p>We discuss technical questions & topics relating to software development on a mailing list.
     Visit the <a href="https://groups.google.com/a/umn.edu/forum/?hl=en&fromgroups#!forum/code-people">Code People Google Group</a> to join the code-people@umn.edu mailing list.</p>
     <p>We are constantly looking for speakers and topic ideas for technical talks.
-    Please email <a href="mailto:code-people-committee@umn.edu">code-people-committee@umn.edu</a> with your ideas.</p>
+    <a href="/request">Here</a> is information on how to request a talk!</p>
   </ul>
 
 </div>


### PR DESCRIPTION
Instead of referencing the committee email address