### PR TITLE
Update 2018-10-04-all-docker.markdown

### DIFF
--- a/_posts/2018-10-04-all-docker.markdown
+++ b/_posts/2018-10-04-all-docker.markdown
@@ -12,7 +12,7 @@ categories: meetings
 Recording:
 
 - Mp4 contains presentation and audio only https://drive.google.com/open?id=1QDSTVedosExD7tAbctlffpDOn1vdPHZT
-- Webex recording link https://umn.webex.com/umn/ldr.php?RCID=0bd60df9a084b8be1a99c89256b277f9
+- Webex recording link https://umn.webex.com/umn/ldr.php?RCID=0067b2504adfd6d0a86138f4e684d0aa
 
 
 Agenda:

--- a/_posts/2018-10-04-all-docker.markdown
+++ b/_posts/2018-10-04-all-docker.markdown
@@ -4,6 +4,7 @@ title: "Docktoberfest"
 date: 2018-10-04 09:30
 categories: meetings
 recording_url: https://drive.google.com/open?id=1QDSTVedosExD7tAbctlffpDOn1vdPHZT
+streaming_url: https://umn.webex.com/umn/ldr.php?RCID=0bd60df9a084b8be1a99c89256b277f9
 ---
 
 - Location: [Walter Library](http://campusmaps.umn.edu/walter-library), Room 402

--- a/_posts/2018-10-04-all-docker.markdown
+++ b/_posts/2018-10-04-all-docker.markdown
@@ -3,13 +3,17 @@ layout: post
 title: "Docktoberfest"
 date: 2018-10-04 09:30
 categories: meetings
-recording_url: https://drive.google.com/open?id=1QDSTVedosExD7tAbctlffpDOn1vdPHZT
-streaming_url: https://umn.webex.com/umn/ldr.php?RCID=0bd60df9a084b8be1a99c89256b277f9
 ---
 
 - Location: [Walter Library](http://campusmaps.umn.edu/walter-library), Room 402
 - Day: Thursday, October 4
 - Time: 9:30 - 11:00
+
+Recording:
+
+- Mp4 contains presentation and audio only https://drive.google.com/open?id=1QDSTVedosExD7tAbctlffpDOn1vdPHZT
+- Webex recording link https://umn.webex.com/umn/ldr.php?RCID=0bd60df9a084b8be1a99c89256b277f9
+
 
 Agenda:
 

--- a/_posts/2018-12-06-experts-sf-kubernetes.markdown
+++ b/_posts/2018-12-06-experts-sf-kubernetes.markdown
@@ -9,6 +9,11 @@ categories: upcoming
 - Day: Thursday, December 6
 - Time: 9:30 - 11:00
 
+Recording:
+
+- Mp4 contains presentation and audio only (56MB) https://drive.google.com/open?id=1_XtuUu8mrlx7Np_WzJ4qLgi9yaRDplrW
+- Webex streaming link https://umn.webex.com/umn/ldr.php?RCID=0bd60df9a084b8be1a99c89256b277f9
+
 Agenda:
 
 - *9:30 - 9:50* **Experts@Minnesota Project**, David Naughton

--- a/_posts/2018-12-06-experts-sf-kubernetes.markdown
+++ b/_posts/2018-12-06-experts-sf-kubernetes.markdown
@@ -12,7 +12,7 @@ categories: upcoming
 Recording:
 
 - Mp4 contains presentation and audio only (56MB) https://drive.google.com/open?id=1_XtuUu8mrlx7Np_WzJ4qLgi9yaRDplrW
-- Webex streaming link https://umn.webex.com/umn/ldr.php?RCID=0bd60df9a084b8be1a99c89256b277f9
+- Webex recording link https://umn.webex.com/umn/ldr.php?RCID=0bd60df9a084b8be1a99c89256b277f9
 
 Agenda:
 

--- a/_posts/2018-12-06-experts-sf-kubernetes.markdown
+++ b/_posts/2018-12-06-experts-sf-kubernetes.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Experts, Salesforce Integration, and kubernetes"
 date: 2018-12-06 09:30
-categories: upcoming
+categories: meetings
 ---
 
 - Location: [Walter Library](http://campusmaps.umn.edu/walter-library), Room 402


### PR DESCRIPTION
Added a streaming link for the direct webex stream of the recording which will include the video portion.