### PR TITLE
Update 2019-02-07-graphql-and-google-calendar-api.markdown

### DIFF
--- a/_posts/2019-02-07-graphql-and-google-calendar-api.markdown
+++ b/_posts/2019-02-07-graphql-and-google-calendar-api.markdown
@@ -3,6 +3,8 @@ layout: post
 title: "GraphQL and Google Calendar API"
 date: 2019-02-07 09:30
 categories: upcoming
+Recording url: Presentation and audio only https://drive.google.com/open?id=1B8Q_zZsn05e31GxlbjVcrIMhEUMxt9OD
+Recording/video: Presentation with video inset https://drive.google.com/open?id=1ls1Ue8xacSA2jKeQ0zpG_rWZelqqiM-Y
 ---
 
 - Location: [Walter Library](http://campusmaps.umn.edu/walter-library), Room 402

--- a/_posts/2019-02-07-graphql-and-google-calendar-api.markdown
+++ b/_posts/2019-02-07-graphql-and-google-calendar-api.markdown
@@ -2,14 +2,18 @@
 layout: post
 title: "GraphQL and Google Calendar API"
 date: 2019-02-07 09:30
-categories: upcoming
-Recording url: Presentation and audio only https://drive.google.com/open?id=1B8Q_zZsn05e31GxlbjVcrIMhEUMxt9OD
-Recording/video: Presentation with video inset https://drive.google.com/open?id=1ls1Ue8xacSA2jKeQ0zpG_rWZelqqiM-Y
+categories: meetings
 ---
 
 - Location: [Walter Library](http://campusmaps.umn.edu/walter-library), Room 402
 - Day: Thursday, February 7
 - Time: 9:30 - 11:00
+
+Recording:
+
+- Mp4 presentation and audio only (55MB) https://drive.google.com/open?id=1B8Q_zZsn05e31GxlbjVcrIMhEUMxt9OD
+- Mp4 presentation with video (2GB) https://drive.google.com/open?id=1ls1Ue8xacSA2jKeQ0zpG_rWZelqqiM-Y
+- Webex recording link https://umn.webex.com/umn/ldr.php?RCID=10ebe3a4cd6730a96b4f80272daf1240
 
 Agenda:
 


### PR DESCRIPTION
Added recording urls. Two options this time. The second one includes the video at a higher resolution.