### PR TITLE
Change message about talk length on request page

### DIFF
--- a/request.md
+++ b/request.md
@@ -8,8 +8,7 @@ We use GitHub Issues to track talk ideas.
 
 - Go to [https://github.umn.edu/code-people/meetings/issues](https://github.umn.edu/code-people/meetings/issues)
 - Click _New Issue_
-- Enter a title and description for your idea
-- Choose a label for the issue depending on if it's a Talk Idea or a Lightning Talk Idea
+- Enter a title and description for your idea. If you are going to give the talk, please include an estimate of how long you think the talk will be
 - Click _Submit new issue_ when you're ready to submit your idea
 
 Once your idea is submitted, we'll get back to you about it!


### PR DESCRIPTION
The instructions used to tell people to select a label for "Talk idea"
or "Lightning Talk Idea" but not all users can add a label to the
issue. Plus "Talk Idea"s can be of varying length and we want to know
how long a "Talk Idea" will be when we want to schedule a meeting.

Address both issues by asking the user to include a talk length when
submitting an issue this means they don't have to add a label and we
(hopefully) get fuller information about time.