### PR TITLE
June 2019 And Online Link

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@ layout: default
   {% if page.recording_url %}
   <p><a href="{{ page.recording_url }}" class="button radius"><i class="fi-play-video"></i> Watch the recorded session</a></p>
   {% else %}
-  <p><a href="http://z.umn.edu/cpmwebex" class="button radius success"><i class="fi-play-video"></i> Participate online</a></p>
+  <p><a href="https://z.umn.edu/cpmstream" class="button radius success"><i class="fi-play-video"></i> Participate online</a></p>
   {% endif %}
 
   {{ content }}

--- a/_posts/2019-04-04-docker-vms-and-tech-portfolio.markdown
+++ b/_posts/2019-04-04-docker-vms-and-tech-portfolio.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Docker on VMs and the Technology Portfolio"
 date: 2019-04-04 09:30
-categories: upcoming
+categories: meetings
 ---
 
 - Location: [Walter Library](http://campusmaps.umn.edu/walter-library), Room 402

--- a/_posts/2019-06-06-canvas-docker-how-it-works.markdown
+++ b/_posts/2019-06-06-canvas-docker-how-it-works.markdown
@@ -1,0 +1,45 @@
+---
+layout: post
+title: "Building a Canvas LTI, Docker for Development, How It Works: the Testing Request Form"
+date: 2019-04-04 09:30
+categories: upcoming
+---
+
+## Meta:
+
+**This meeting will be in person in Bruininks 131B and online on [Zoom](z.umn.edu/cpmwebex)**
+
+- Location: [Bruininks Hall](https://campusmaps.umn.edu/robert-h-bruininks-hall), Room 131B
+- Day: Thursday, June 6
+- Time: 9:30 - 11:00
+
+## Agenda:
+
+- 9:30 - Introductions
+- 9:35 - 9:55 [Getting started building an LTI](#getting-started-building-an-lti), Colin McFadden
+- 9:55 - 10:10 [Using Docker for Development and Deployment of Off the Shelf Software](#using-docker-for-development-and-deployment-of-off-the-shelf-software), Travis Sobeck
+- 10:20 - 10:25 Break
+- 10:25 - 10:40 [How It Works - The Anatomy of the Testing Request Form](#how-it-works-the-anatomy-of-the-testing-request-form), Tonu Mikk
+- 10:40 - 11:00 Lightning talks
+  - How It Works - a Talk Template (Tonu Mikk/Colin McFadden)
+  - _Bring your own_
+
+As always, join us after the meeting for lunch!
+
+## Talk Descriptions:
+
+### Getting started building an LTI
+Colin McFadden (Technology Architect | LATIS)
+
+> This talk will explore the Learning Tools Interoperability (LTI) technology, which allows for third party apps to extend a learning management platform like Canvas.  LTI can be incredibly overwhelming, but it doesn’t have to be - you can build simple LTI integration into your app without needing to become an LTI expert.
+
+### Using Docker for Development and Deployment of Off the Shelf Software
+Travis Sobeck (Core Infrastructure Admin | OIT)
+
+> Docker is great for playing with a new language or product, testing and deploying software someone else produced, and of course developing your own software.  I will share some tips, tricks, and code to help you get started and discuss what can and can not be put in a container.
+
+### How It Works: The Anatomy of the Testing Request Form
+Tonu Mikk (Adaptive Technologist | Disability Resource Center)
+
+>This talk will describe the custom built web form that students use to request exams to be taken at the Disability Resource Center.  We overview the features of the form and how these features are supported by various technologies - Shibboleth, Apache with reverse proxy configuration, 4D, Foundation CSS, Data Warehouse, Active4D, and Javascript.
+

--- a/_posts/2019-06-06-canvas-docker-how-it-works.markdown
+++ b/_posts/2019-06-06-canvas-docker-how-it-works.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Building a Canvas LTI, Docker for Development, How It Works: the Testing Request Form"
-date: 2019-04-04 09:30
+date: 2019-06-06 09:30
 categories: upcoming
 ---
 
@@ -16,19 +16,19 @@ categories: upcoming
 ## Agenda:
 
 - 9:30 - Introductions
-- 9:35 - 9:55 [Getting started building an LTI](#getting-started-building-an-lti), Colin McFadden
+- 9:35 - 9:55 [Getting Started With Building an LTI](#getting-started-with-building-an-lti), Colin McFadden
 - 9:55 - 10:10 [Using Docker for Development and Deployment of Off the Shelf Software](#using-docker-for-development-and-deployment-of-off-the-shelf-software), Travis Sobeck
 - 10:20 - 10:25 Break
 - 10:25 - 10:40 [How It Works - The Anatomy of the Testing Request Form](#how-it-works-the-anatomy-of-the-testing-request-form), Tonu Mikk
 - 10:40 - 11:00 Lightning talks
-  - How It Works - a Talk Template (Tonu Mikk/Colin McFadden)
+  - How It Works - a Talk Template
   - _Bring your own_
 
 As always, join us after the meeting for lunch!
 
 ## Talk Descriptions:
 
-### Getting started building an LTI
+### Getting Started With Building an LTI
 Colin McFadden (Technology Architect | LATIS)
 
 > This talk will explore the Learning Tools Interoperability (LTI) technology, which allows for third party apps to extend a learning management platform like Canvas.  LTI can be incredibly overwhelming, but it doesn’t have to be - you can build simple LTI integration into your app without needing to become an LTI expert.


### PR DESCRIPTION
Get the website ready for the June meeting:

* update the meeting template for zoom
* move April to past meetings
* Add June

Since this is the first month that we have talk descriptions, I'm attaching a screenshot so you can see what my formatting changes look like. The talk descriptions go on for a while, and including it all made things hard to read, so I cut it off at the start of the description for the first talk


<img width="664" alt="june_2019_meeting_layout" src="https://user-images.githubusercontent.com/2103414/58508264-461eb200-8159-11e9-93d1-32ef9308df26.png">
