### PR TITLE
Fix zoom link in body of June 2019 page

### DIFF
--- a/_posts/2019-06-06-canvas-docker-how-it-works.markdown
+++ b/_posts/2019-06-06-canvas-docker-how-it-works.markdown
@@ -7,7 +7,7 @@ categories: upcoming
 
 ## Meta:
 
-**This meeting will be in person in Bruininks 131B and online on [Zoom](z.umn.edu/cpmwebex)**
+**This meeting will be in person in Bruininks 131B and online on [Zoom](https://z.umn.edu/cpmstream)**
 
 - Location: [Bruininks Hall](https://campusmaps.umn.edu/robert-h-bruininks-hall), Room 131B
 - Day: Thursday, June 6


### PR DESCRIPTION
Fixing errors with the zoom link the body of the June 2019 page - I managed to make the link relative and for the wrong z link. The link in the template seems right. Fixing the june meeting page.