### PR TITLE
Create post for Dec 2020 meeting

### DIFF
--- a/_posts/2020-12-03-cpm.md
+++ b/_posts/2020-12-03-cpm.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: "Git Workshop"
+date: 2020-12-03 09:30
+categories: upcoming
+---
+
+## Meta:
+
+- Location: [Zoom](https://z.umn.edu/cpmstream)
+- Day: Thursday, December 3
+- Time: 9:30
+
+## Agenda:
+
+- Introductions
+- Intro to UMN GitHub  
+- Workshop on Git and GitHub
+- [Lightning Talks](https://code-people.umn.edu/speaker_info/)
+  - _Bring Your Own!_
+
+## Talk Descriptions:
+
+### Intro to UMN GitHub
+Peter Bajurny, OIT Infrastructure & Production
+
+>Details to come!
+
+
+### Workshop on Git and GitHub
+Code People Committee
+
+>Details to come!


### PR DESCRIPTION
Details aren't finalized, but this will get a page on the site for the upcoming Dec 3 meeting. 